### PR TITLE
Corrected typo in constitution

### DIFF
--- a/content/constitution/contents.lr
+++ b/content/constitution/contents.lr
@@ -74,7 +74,7 @@ The President shall
 The Vice President shall
 
 - call meetings of the executive and the society;
-- manage everyday running of the the society;
+- manage everyday running of the society;
 - handle society financial matters, and serve as a co-signing authority for all society financial transactions.
 - assume the duties of president in their absence or at their request.
 


### PR DESCRIPTION
Replaced "the the society" with "the society" in the constitution's description of the duties of the Vice President.