### PR TITLE
Add links to /archives to older home pages

### DIFF
--- a/content/archives/contents.lr
+++ b/content/archives/contents.lr
@@ -7,3 +7,11 @@ body:
 - [Meetings](/archives/meetings)
 - [Treasury](/archives/treasury)
 - [IRC](/archives/irc)
+
+###### Below are links to content hosted our _csclub_ LabNet account:
+
+- [Home Page - 2001](http://www.cs.mun.ca/~csclub/archive/home_page_2001/)
+- [Home Page - 2003](http://www.cs.mun.ca/~csclub/archive/home_page_2003/)
+- [Home Page - 2005](http://www.cs.mun.ca/~csclub/archive/home_page_2005/)
+
+- [Misc. Photos and Documents](http://www.cs.mun.ca/~csclub/archive/photos_and_documents/)

--- a/content/archives/irc/contents.lr
+++ b/content/archives/irc/contents.lr
@@ -11,9 +11,10 @@ Server: irc.synirc.net
 Port: 6667 (or 7001 for SSL)
 
 Channel: #muncssociety
+
+Enter a nickname to get started and join the channel!
+
 ---
 embedded:
-
-<p>Enter a nickname to get started and join the channel!</p>
 
 <iframe src="https://kiwiirc.com/client/irc.synirc.net/#muncssociety" style="border:0; width:100%; height:450px;"></iframe>


### PR DESCRIPTION
Who knew we had a labnet account sitting around collecting dust containing some classic webpages from the society?

Some files older than myself 👀 .

I cleaned them up quite a bit, and a more tidy version of what was there before can be found at:

http://www.cs.mun.ca/~csclub/archive/

# What

- Adds links to the `contents.lr` file within `/archive` to filed hosted on `www.cs.mun.ca/~csclub/`
- Also moved `<p>` tag to markdown in the irc page

# Test

- Check speling and f  ormat ign