### PR TITLE
Remove need to install Bootstrap from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The content for the site lives in the `content/` folder. Fork this repo and send
 Dependencies
 ----------------
 
-Install [Lektor](https://www.getlektor.com/), and [Bootstrap](http://getbootstrap.com/) before proceeding.
+Install [Lektor](https://www.getlektor.com/) before proceeding.
 
 Local Installation
 ----------------------


### PR DESCRIPTION
You don't actually have to install anything but Lektor to run the project, the minified source for Bootstrap 4 is already within the project files.