### PR TITLE
Add Faculty page, w/current non-dead faculty links

### DIFF
--- a/content/resources/contents.lr
+++ b/content/resources/contents.lr
@@ -8,6 +8,7 @@ If you have ideas for tutorials to write or seminars to hold, send them to us.
 
 * [Tutorials](/resources/tutorials)
 * [Courses](/resources/courses)
+* [Faculty](/resources/faculty)
 
 ## Press Resources
 

--- a/content/resources/faculty/contents.lr
+++ b/content/resources/faculty/contents.lr
@@ -1,0 +1,37 @@
+title: Faculty
+---
+body:
+
+# Faculty
+
+Below is a _noncomprehensive_ list of homepages for various computer science faculty members, potentially outdated/dead links.
+
+* Adrian Fiech - [afiech](http://www.cs.mun.ca/~afiech/), [fiech](http://www.cs.mun.ca/~fiech/)
+* Andrew Vardy - [av](http://www.cs.mun.ca/~av/)
+* Wolfgang Banzhaf - [banzhaf](http://www.cs.mun.ca/~banzhaf/)
+* Miklos Bartha - [bartha](http://www.cs.mun.ca/~bartha/)
+* Edward Brown - [brown](http://www.cs.mun.ca/~brown/)
+* David Churchill - [dchurchill](http://www.cs.mun.ca/~dchurchill/)
+* Donna Batten - [donna](http://www.cs.mun.ca/~donna/)
+* George Miminis - [george](http://www.cs.mun.ca/~george/)
+* Minglun Gong - [gong](http://www.cs.mun.ca/~gong/)
+* Todd Wareham - [harold](http://www.cs.mun.ca/~harold/)
+* Jian Tang - [jian](http://www.cs.mun.ca/~jian/)
+* Antonina Kolokolova - [kol](http://www.cs.mun.ca/~kol/)
+* Lourdes Peña-Castillo - [lourdes](http://www.cs.mun.ca/~lourdes/)
+* Malgosia S. Zuberek - [malgosia](http://www.cs.mun.ca/~malgosia/)
+* Manrique Mata-Montero - [manrique](http://www.cs.mun.ca/~manrique/)
+* Nolan White - [nolan](http://www.cs.mun.ca/~nolan/)
+* Oscar Meruvia-Pastor - [omeruvia](http://www.cs.mun.ca/~omeruvia/)
+* Paul Gillard - [paul](http://www.cs.mun.ca/~paul/)
+* Rod Byrne - [rod](http://www.cs.mun.ca/~rod/)
+* Sharene D. Bungay - [sharene](http://www.cs.mun.ca/~sharene/)
+* John S. Shieh - [shunen](http://www.cs.mun.ca/~shunen/)
+* Simon Harding - [simonh](http://www.cs.mun.ca/~simonh/)
+* Siwei Lu - [swlu](http://www.cs.mun.ca/~swlu/)
+* Gwoing Tina Yu - [tinayu](http://www.cs.mun.ca/~tinayu/)
+* Ting Hu - [tingh](http://www.cs.mun.ca/~tingh/)
+* Krishnamurthy Vidyasankar - [vidya](http://www.cs.mun.ca/~vidya/)
+* Caoan Wang - [wang](http://www.cs.mun.ca/~wang/)
+* Wlodek M. Zuberek - [wlodek](http://www.cs.mun.ca/~wlodek/)
+* Yuanzhu Chen - [yzchen](http://www.cs.mun.ca/~yzchen/)


### PR DESCRIPTION
# What
Plenty of interesting MUN-related content can be found on the homepages of professors, but this content is nowhere to be found currently on our website.

# Test
There's quite a few links, but test a handful and make sure they're not
- Dead
- Pointing to the wrong person