### PR TITLE
Simplified setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cd Website
 # Launch a Lektor server to auto-compile and host the site
 lektor server
 
-# Now go to localhost:5000
+# Now go to http://localhost:5000 in a web browser
 ```
 
 Auto-updates

--- a/README.md
+++ b/README.md
@@ -24,15 +24,10 @@ git clone https://github.com/MUNComputerScienceSociety/Website
 # Enter cloned folder
 cd Website
 
-# Compile
-lektor build
-# To specify which folder to build to, append
-lektor build --output-path folder-name
+# Launch a Lektor server to auto-compile and host the site
+lektor server
 
-# Spin up a webserver in the outputs directory, for example:
-cd /lektor/build/output/folder-name
-python -m SimpleHTTPServer
-# Then open http://localhost:8000 in a web browser
+# Now go to localhost:5000
 ```
 
 Auto-updates


### PR DESCRIPTION
Setup instructions now use the `lektor server` command, rather than `lektor build` to compile the site, followed by `python -m SimpleHTTPServer` to host, which would only work when python pointed to python2, rather than python3.