### PR TITLE
Update links to new fork not on mikes account

### DIFF
--- a/content/resources/workshops/gamedev/contents.lr
+++ b/content/resources/workshops/gamedev/contents.lr
@@ -22,7 +22,7 @@ This workshop will focus on familiarizing participants with the overall Unity ed
 
 Content for this workshop is available to download [here](http://www.cs.mun.ca/~csclub/workshops/gamedev/workshop1/).
 
-Or via GitHub [here](https://github.com/michaelgburton/unity-workshop/tree/master/Workshop_1).
+Or via GitHub [here](https://github.com/gamedev-nl/unity-workshop/tree/master/Workshop_1)
 
 # We will have some desktops available to use, however we highly recommend you bring your own laptop with [Unity already installed](https://unity3d.com/get-unity/download) beforehand.
 
@@ -43,4 +43,4 @@ Exact dates, locations, and order are yet to be determined.
 
 We will be posting associated code to a public repository located here: 
 
-https://github.com/michaelgburton/unity-workshop
+[https://github.com/gamedev-nl/unity-workshop](https://github.com/gamedev-nl/unity-workshop)


### PR DESCRIPTION
Mike from GDNL sent me this:
> Can someone from MUNCSS please change the URL for the code on https://muncompsci.ca/resources/workshops/gamedev/ to point to the fork owned by the gamedev-nl account please? (https://github.com/gamedev-nl/unity-workshop)

This PR fixes this request